### PR TITLE
resolving link error in home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 export default function Home() {
   return (
     <div className="text-center">


### PR DESCRIPTION
Solved a vercel Link error

"./src/app/not-found.tsx
14:53  Error: `'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`.  react/no-unescaped-entities"
